### PR TITLE
Update LiveBlogEpic and TopBarSupport components

### DIFF
--- a/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
+++ b/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
@@ -30,7 +30,7 @@ type Props = {
 	keywordIds: string;
 };
 
-const useEpic = ({ url, name }: { url: string; name: string }) => {
+const useEpic = ({ name }: { name: string }) => {
 	// Using state here to store the Epic component that gets imported allows
 	// us to render it with React (instead of inserting it into the dom manually)
 	const [Epic, setEpic] =
@@ -51,7 +51,7 @@ const useEpic = ({ url, name }: { url: string; name: string }) => {
 					'liveblog-epic',
 				);
 			});
-	}, [url, name]);
+	}, [name]);
 
 	return { Epic };
 };
@@ -145,21 +145,18 @@ const usePayload = ({
  * Dynamically imports and renders a given module
  *
  * @param props
- * @param props.url string - The url of the component
- * @param props.name tring - The name of the component
+ * @param props.name string - The name of the component
  * @param props.props object - The props of the component
  * @returns The resulting react component
  */
 const Render = ({
-	url,
 	name,
 	props,
 }: {
-	url: string;
 	name: string;
 	props: { [key: string]: unknown };
 }) => {
-	const { Epic } = useEpic({ url, name });
+	const { Epic } = useEpic({ name });
 
 	if (isUndefined(Epic)) return null;
 	log('dotcom', 'LiveBlogEpic has the Epic');
@@ -209,7 +206,6 @@ const Fetch = ({
 	// Take any returned module and render it
 	return (
 		<Render
-			url={response.data.module.url}
 			name={response.data.module.name}
 			props={props}
 		/>

--- a/dotcom-rendering/src/components/TopBarSupport.importable.tsx
+++ b/dotcom-rendering/src/components/TopBarSupport.importable.tsx
@@ -99,7 +99,7 @@ const ReaderRevenueLinksRemote = ({
 				setSupportHeaderResponse(module);
 
 				return (
-					module.url.includes('SignInPromptHeader')
+					module.name === 'SignInPromptHeader'
 						? /* webpackChunkName: "sign-in-prompt-header" */
 						  import(`./marketing/header/SignInPromptHeader`)
 						: /* webpackChunkName: "header" */


### PR DESCRIPTION
## What does this change?

*   Removes all instances of the `url` field from `LiveBlogEpic.importable.tsx`.
*   Updates `TopBarSupport.importable.tsx` to use the `name` field instead of `url` for checking equality with `'SignInPromptHeader'`.

## Why?

SDC (support-dotcom-components) no longer returns a `url` field in its response, and DCR does not use this field. These changes ensure compatibility with the updated SDC response structure by removing the deprecated `url` field usage and correctly identifying components using the `name` field.

## Screenshots

| Before | After |
| ------ | ----- |
| N/A    | N/A   |

---
<a href="https://cursor.com/background-agent?bcId=bc-dccf8465-eacc-40b8-b526-fbe6ad4aa0ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dccf8465-eacc-40b8-b526-fbe6ad4aa0ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

