### PR TITLE
Update LiveBlogEpic and TopBarSupport components

### DIFF
--- a/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
+++ b/dotcom-rendering/src/components/LiveBlogEpic.importable.tsx
@@ -30,7 +30,7 @@ type Props = {
 	keywordIds: string;
 };
 
-const useEpic = ({ url, name }: { url: string; name: string }) => {
+const useEpic = ({ name }: { name: string }) => {
 	// Using state here to store the Epic component that gets imported allows
 	// us to render it with React (instead of inserting it into the dom manually)
 	const [Epic, setEpic] =
@@ -51,7 +51,7 @@ const useEpic = ({ url, name }: { url: string; name: string }) => {
 					'liveblog-epic',
 				);
 			});
-	}, [url, name]);
+	}, [name]);
 
 	return { Epic };
 };
@@ -145,21 +145,18 @@ const usePayload = ({
  * Dynamically imports and renders a given module
  *
  * @param props
- * @param props.url string - The url of the component
- * @param props.name tring - The name of the component
+ * @param props.name string - The name of the component
  * @param props.props object - The props of the component
  * @returns The resulting react component
  */
 const Render = ({
-	url,
 	name,
 	props,
 }: {
-	url: string;
 	name: string;
 	props: { [key: string]: unknown };
 }) => {
-	const { Epic } = useEpic({ url, name });
+	const { Epic } = useEpic({ name });
 
 	if (isUndefined(Epic)) return null;
 	log('dotcom', 'LiveBlogEpic has the Epic');
@@ -209,7 +206,6 @@ const Fetch = ({
 	// Take any returned module and render it
 	return (
 		<Render
-			url={response.data.module.url}
 			name={response.data.module.name}
 			props={props}
 		/>
@@ -227,7 +223,7 @@ function insertAfter(referenceNode: HTMLElement, newNode: Element) {
  *
  * 1. usePayload - Build the payload. The config object we send to contributions
  * 2. Fetch - POST the payload to the contributions endpoint
- * 3. Render - Take the url, props and name data we got in response to our fetch and dynamically import
+ * 3. Render - Take the props and name data we got in response to our fetch and dynamically import
  *    and render the Epic component using it
  *
  * ## Why does this need to be an Island?

--- a/dotcom-rendering/src/components/TopBarSupport.importable.tsx
+++ b/dotcom-rendering/src/components/TopBarSupport.importable.tsx
@@ -99,7 +99,7 @@ const ReaderRevenueLinksRemote = ({
 				setSupportHeaderResponse(module);
 
 				return (
-					module.url.includes('SignInPromptHeader')
+					module.name === 'SignInPromptHeader'
 						? /* webpackChunkName: "sign-in-prompt-header" */
 						  import(`./marketing/header/SignInPromptHeader`)
 						: /* webpackChunkName: "header" */


### PR DESCRIPTION
## What does this change?

- Removed all instances of the `url` field from `LiveBlogEpic.importable.tsx`.
- Updated `TopBarSupport.importable.tsx` to check `module.name === 'SignInPromptHeader'` instead of `module.url.includes('SignInPromptHeader')`.

## Why?

SDC (support-dotcom-components) no longer returns a `url` field in its response. This change aligns the code with the DCR (dotcom-rendering) implementation, which uses the `name` field for component identification.

## Screenshots

| Before | After |
| --- | --- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

---
<a href="https://cursor.com/background-agent?bcId=bc-455a5ac1-4f30-47ec-8439-7a0161452d7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-455a5ac1-4f30-47ec-8439-7a0161452d7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

